### PR TITLE
Add ability to set permissions in file navigator.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,1 +1,3 @@
+python-magic
 Flask
+Flask-API

--- a/uploader/Navigator/permissions.py
+++ b/uploader/Navigator/permissions.py
@@ -1,0 +1,46 @@
+import csv
+import json
+import os
+
+
+PERMISSION_METADATA_FILENAME = "permissions.json"
+
+
+def read_permissions(permission_file_path):
+    # Read permissions from JSON if applicable
+    try:
+        with open(permission_file_path) as data:
+            permissions = json.load(data)
+    except FileNotFoundError:
+        permissions = {}
+
+    return permissions
+
+
+def set_permission(permission_file_path, entry_path, permission):
+    permissions = read_permissions(permission_file_path)
+
+    permissions[entry_path] = permission
+
+    # Write permissions to JSON
+    file = open(permission_file_path, "w")
+    file.write(json.dumps(permissions))
+    file.close()
+
+
+def write_permissions_to_csv(transfer_dir, destination_csv_file_path):
+    permission_filepath = os.path.join(transfer_dir, PERMISSION_METADATA_FILENAME)
+    permissions = read_permissions(permission_filepath)
+
+    with open(destination_csv_file_path, 'w', newline='') as csvfile:
+        fieldnames = ["filename", "dc.rights"]
+        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+
+        # Write header
+        writer.writeheader()
+
+        # Write rows in order
+        for filename in sorted(permissions.keys()):
+            if permissions[filename] != "":
+                filename_fixed = filename.replace(transfer_dir, "objects")
+                writer.writerow({"filename": filename_fixed, "dc.rights": permissions[filename]})

--- a/uploader/Navigator/templates/files.html
+++ b/uploader/Navigator/templates/files.html
@@ -3,28 +3,51 @@
 {% block content %}
 
   <div class="container mt-5">
-  <h2>Files {{ currdir }}</h2> </br>
 
-  {%- if back_path|length -%}
-    <a href="{{ back_path }}">
-      Back
-    </a>
-  {%- endif %}
+    <h2>Files {{ currdir }}</h2> </br>
 
-  <table class="table">
-    {% for entry in entries %}
-      <tr>
-        <td>
-          <a href="{{ (request.path + '/' if request.path != '/' else '') + entry.name }}">
-            {{ entry.name }}
-          </a>
-        </td>
-        <td>
-          {{ entry.size|filesizeformat }}
-        </td>
-      </tr>
-    {% endfor %}
-  </table>
+    {%- if back_path|length -%}
+      <a href="{{ back_path }}">
+        <i class='fas fa-folder'></i> Back
+      </a>
+    {%- endif %}
+
+    <form action="{{ request.path }}" method="POST">
+    <table class="table">
+      {% for entry in entries %}
+        <tr>
+          <td>
+            {% if entry.is_dir %}
+              <a href="{{ request.path }}{{ '/' if req_path else '' }}{{ entry.name }}">
+                <i class='fas fa-folder'></i>
+                {{ entry.name }}
+              </a>
+            {% else %}
+              {{ entry.name }}
+            {% endif %}
+          </td>
+          <td>
+            {{ entry.size|filesizeformat }}
+          </td>
+          <td>
+            {{ entry.mimetype }}
+          </td>
+          <td>
+            {% if not (req_path == '' and entry.name == permissions_filename) %}
+            <select name="perm_{{ entry.path_md5 }}">
+              <option value="" {% if entry.permission == "" %}selected{% endif %}></option>
+              <option value="public" {% if entry.permission == "public" %}selected{% endif %}>Public</option>
+              <option value="restricted" {% if entry.permission == "restricted" %}selected{% endif %}>Restricted</option>
+              <option value="private" {% if entry.permission == "private" %}selected{% endif %}>Private</option>
+            </select>
+            {% endif %}
+          </td>
+        </tr>
+      {% endfor %}
+    </table>
+
+    <input type="submit" class="btn btn-primary"/>
+    </form>
   </div>
 
 {% endblock %}

--- a/uploader/Navigator/views.py
+++ b/uploader/Navigator/views.py
@@ -1,27 +1,29 @@
 # -*- coding: utf-8 -*-
 
+import hashlib
 import os
-from flask import Blueprint, redirect, url_for, abort, render_template, send_file
+import tempfile 
 
-BASE_DIR = '/tmp'
+from flask import Blueprint, redirect, abort, render_template, session, send_file, request, flash, current_app
+import magic
+
+from uploader.Navigator import permissions
+from uploader.Transfer import helpers
 
 navigator = Blueprint("navigator", __name__, template_folder="templates")
 
-#@navigator.route("/files", methods=["GET"])
-@navigator.route('/', defaults={'req_path': ''})
-@navigator.route('/<path:req_path>')
+@navigator.route('/', defaults={'req_path': ''}, methods=["GET", "POST"])
+@navigator.route('/<path:req_path>', methods=["GET", "POST"])
 def index(req_path):
-    """Define handling for application's / route."""
-    # Joining the base and the requested path
-    abs_path = os.path.join(BASE_DIR, req_path)
+    transfer_dir = helpers.get_transfer_directory()
 
-    # Return 404 if path doesn't exist
-    if not os.path.exists(abs_path):
+    # Joining the transfer directory and the requested path
+    abs_path = os.path.join(transfer_dir, req_path)
+    permission_file_path = os.path.join(transfer_dir, permissions.PERMISSION_METADATA_FILENAME)
+
+    # Return 404 if path doesn't exist or path is a file
+    if not os.path.exists(abs_path) or os.path.isfile(abs_path):
         return abort(404)
-
-    # Check if path is a file and serve
-    if os.path.isfile(abs_path):
-        return send_file(abs_path)
 
     # Assemble back link path
     back_path = ""
@@ -29,16 +31,52 @@ def index(req_path):
         back_path = "/files/" + "/".join(req_path.split("/")[0:-1])
         back_path = back_path.rstrip("/")
 
-    # Show directory contents
+    # Get directory contents
     files = os.listdir(abs_path)
+
+    # Update permissions data, if sent
+    if request.method == 'POST':
+        for file in files:
+            entry_path = os.path.join(abs_path, file)
+            form_field_name = "perm_" + hashlib.md5(entry_path.encode('utf-8')).hexdigest()
+
+            if form_field_name in request.form:
+                permission = request.form[form_field_name]
+
+                permissions.set_permission(permission_file_path, entry_path, permission)
+
+        flash("Updated.", "primary")
+        redirect(request.path)
+
+    # Assemble directory data
+    permission_data = permissions.read_permissions(permission_file_path)
 
     entries = []
     for file in files:
         entry_path = os.path.join(abs_path, file)
 
-        entries.append({
+        entry = {
             "name": file,
-            "size": os.path.getsize(entry_path)
-        })
+            "size": os.path.getsize(entry_path),
+            "is_dir": os.path.isdir(entry_path),
+            "path_md5": hashlib.md5(entry_path.encode('utf-8')).hexdigest()
+        }
 
-    return render_template('files.html', entries=entries, back_path=back_path)
+        if not entry["is_dir"]:
+            entry["mimetype"] = magic.from_file(entry_path, mime = True)
+
+        if entry_path in permission_data:
+            entry["permission"] = permission_data[entry_path]
+
+        entries.append(entry)
+
+    return render_template('files.html', entries=entries, req_path=req_path, back_path=back_path, permissions_filename=permissions.PERMISSION_METADATA_FILENAME)
+
+@navigator.route('/preview', methods=["GET"])
+def preview():
+    transfer_dir = helpers.get_transfer_directory()
+    csv_tempfile = tempfile.NamedTemporaryFile()
+
+    permissions.write_permissions_to_csv(transfer_dir, csv_tempfile.name)
+
+    return send_file(csv_tempfile.name, as_attachment=True, mimetype="text/csv", download_name="metadata.csv")

--- a/uploader/Transfer/templates/transfer.html
+++ b/uploader/Transfer/templates/transfer.html
@@ -14,7 +14,7 @@
       <p>File count: {{ transfer_file_count }}</p>
       <p>Total size of files: {{ transfer_total_file_size|filesizeformat }}</p>
 
-      <p><a href="/files">File permissions</a></p>
+      <p><a href="/files">File permissions</a> <a href="/files/preview">(Preview metadata)</a></p>
     {% endif %}
 
     {% if not transfer_preset: %}


### PR DESCRIPTION
* Add ability to set directory/file permissions via file navigator
* Store directory/file permission in JSON file
* Allow navigator transfer directory to be set from configuration
* Remove file viewing (to prevent accidental download of large files,
  etc.)
* Show file MIME type in file navigator
* Add logic for writing CSV file from permissions data
* Add "preview" action to download permissions data as CSV