### PR TITLE
Data upload capability and copy to Archivematica

### DIFF
--- a/config.py
+++ b/config.py
@@ -4,7 +4,8 @@ class Config:
     # Be sure to set a secure secret key for production.
     SECRET_KEY = os.getenv("SECRET_KEY", "you-will-never-guess")
 
-    TRANSFER_DIRECTORY = os.getenv("DATA_DIRECTORY")
+    DATA_DIRECTORY = os.getenv("DATA_DIRECTORY")
+    TRANSFER_SOURCE_DIRECTORY = os.getenv("TRANSFER_SOURCE_DIRECTORY")
     DEBUG = os.getenv("DEBUG") == "True"
     TESTING = False
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,4 @@
 python-magic
 Flask
 Flask-API
+pysqlite3

--- a/uploader/Metadata/__init__.py
+++ b/uploader/Metadata/__init__.py
@@ -1,0 +1,1 @@
+DATAVERSE_METADATA_FILENAME = "dv_metadata.json"

--- a/uploader/Metadata/templates/done.html
+++ b/uploader/Metadata/templates/done.html
@@ -1,0 +1,4 @@
+{% extends "base.html" %}
+
+{% block content %}
+{% endblock %}

--- a/uploader/Metadata/views.py
+++ b/uploader/Metadata/views.py
@@ -2,7 +2,11 @@
 
 
 import json
-from flask import Blueprint, render_template, request
+import os
+from flask import Blueprint, render_template, request, flash, redirect, url_for
+
+from uploader.Metadata import DATAVERSE_METADATA_FILENAME
+from uploader.Transfer import helpers
 
 metadata = Blueprint("metadata", __name__, template_folder="templates")
 
@@ -236,8 +240,16 @@ def index(req_path):
             "licence": {"name": licence_value},
             "value": licence_description_value,
         }
-        with open("./dv_metadata.json", "w") as dv_metadata_file:
+
+        filepath = os.path.join(helpers.get_transfer_directory(), DATAVERSE_METADATA_FILENAME)
+        with open(filepath, "w") as dv_metadata_file:
             json.dump(dv_metadata, dv_metadata_file, indent=4)
 
-        return dv_metadata
+        flash("Metadata saved.", "primary")
+        return redirect(url_for('metadata.updated'))
+
     return render_template("metadata.html")
+
+@metadata.route("/updated", methods=["GET"])
+def updated():
+    return render_template("done.html")

--- a/uploader/Navigator/templates/files.html
+++ b/uploader/Navigator/templates/files.html
@@ -41,7 +41,7 @@
             {{ entry.mimetype }}
           </td>
           <td>
-            {% if not (req_path == '' and entry.name == permissions_filename) and not entry.is_dir: %}
+            {% if entry.settable: %}
               <select name="perm_{{ entry.path_md5 }}">
                 <option value="" {% if entry.permission == "" %}selected{% endif %}></option>
                 <option value="public" {% if entry.permission == "public" %}selected{% endif %}>Public</option>

--- a/uploader/Transfer/helpers.py
+++ b/uploader/Transfer/helpers.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 
 from flask import current_app, flash, session
 
@@ -18,19 +19,31 @@ def directory_count_and_size(directory):
 
     return count, size
 
-def get_transfer_directory(send_flash=False):
+def get_data_directory():
+    if data_directory_set_in_config():
+        return current_app.config["DATA_DIRECTORY"]
+
+    return tempfile.gettempdir()
+
+def get_transfer_directory():
     transfer_dir = ""
 
     if "transfer_directory" in session:
         transfer_dir = session["transfer_directory"]
 
-    if transfer_directory_set_in_config():
-        transfer_dir = current_app.config["TRANSFER_DIRECTORY"]
-
-        if send_flash:
-            flash(f"Using research data at {transfer_dir}", "warning")
-
     return transfer_dir
 
-def transfer_directory_set_in_config():
-    return "TRANSFER_DIRECTORY" in current_app.config and current_app.config["TRANSFER_DIRECTORY"] is not None
+def data_directory_set_in_config():
+    return "DATA_DIRECTORY" in current_app.config and current_app.config["DATA_DIRECTORY"] is not None
+
+def get_all_filepaths_in_directory(directory, trim_root=True):
+    files = []
+
+    for root, _, dir_files in os.walk(directory, topdown=False):
+        for name in dir_files:
+            if trim_root:
+                files.append(os.path.join(root.replace(directory, ''), name))
+            else:
+                files.append(os.path.join(root, name))
+
+    return files

--- a/uploader/Transfer/templates/transfer.html
+++ b/uploader/Transfer/templates/transfer.html
@@ -4,27 +4,29 @@
 
   <div class="container mt-5">
 
-    <h2>Select Research Data</h2>
+    {% if transfer_directory: %}
+      <h2>Update Research Data</h2>
 
-    {% if not transfer_preset: %}
-      <p>
-        Current research data directory:<br/>
-        <code>{{ transfer_directory }}</code>
-      </p>
+      <table>
+        <tr>
+          <td>File count: </td>
+          <td><code>{{ transfer_file_count }}</code> <span class="text-muted small">(including generated metadata)</span></td>
+        </tr>
+        <tr>
+          <td>Total size of files: </td>
+          <td><code>{{ transfer_total_file_size|filesizeformat }}</code></td>
+        </tr>
+      </table>
 
-      <form action="{{ url_for('transfer.update') }}" method="POST">
-        <div class="mb-3">
-          <label for="transfer_directory" class="form-label">Change directory:</label>
-          <input name="transfer_directory"/>
-        </div>
-
-        <div class="mb-3">
-          <input type="submit" value="Set Directory" class="btn btn-primary"/>
-        </div>
-      </form>
     {% else %}
-      <p>Research data directory set by environment variable.</p>
+      <h2>Upload Research Data</h2>
     {% endif %}
+
+    </br>
+    <form action="{{ url_for('transfer.upload') }}" method="POST" enctype="multipart/form-data">
+      <input name="files" type="file" webkitdirectory directory />
+      <input type=submit value="Upload" class="btn btn-primary"/>
+    </form>
 
   </div>
 

--- a/uploader/Transfer/views.py
+++ b/uploader/Transfer/views.py
@@ -1,36 +1,74 @@
 # -*- coding: utf-8 -*-
 
 import os
+import tempfile
+import zipfile
+
 from flask import Blueprint, render_template, request, session, flash, redirect, url_for
 from flask_api import status
+from werkzeug.utils import secure_filename
 
+from uploader.Navigator import permissions
 from uploader.Transfer import helpers
 
 transfer = Blueprint("transfer", __name__, template_folder="templates")
 
 @transfer.route('/')
 def index():
-    transfer_dir = helpers.get_transfer_directory(True)
-    transfer_preset = helpers.transfer_directory_set_in_config()
+    transfer_dir = helpers.get_transfer_directory()
 
-    return render_template('transfer.html', transfer_directory=transfer_dir, transfer_preset=transfer_preset)
+    transfer_file_count, transfer_total_file_size = helpers.directory_count_and_size(
+        transfer_dir
+    )
 
-@transfer.route('/research', methods=["POST"])
-def update():
-    transfer_dir = request.form["transfer_directory"]
+    return render_template('transfer.html', transfer_directory=transfer_dir, transfer_file_count=transfer_file_count, transfer_total_file_size=transfer_total_file_size)
 
-    if transfer_dir:
-        if not os.path.exists(transfer_dir):
-            flash("Path does not exist.", "danger")
-            return redirect(url_for('transfer.index'))
-        elif os.path.isfile(transfer_dir):
-            flash("Path is a file not a directory.", "danger")
-            return redirect(url_for('transfer.index'))
-        else:
-            session["transfer_directory"] = request.form["transfer_directory"]
-            session.modified = True
+@transfer.route('/upload', methods=['POST'])
+def upload():
+    # Check if the post request has the file part
+    if 'files' not in request.files:
+        flash("No file part", "danger")
+        return redirect(url_for('transfer.index'))
 
-            flash("Updated.", "primary")
-            return redirect(url_for('transfer.index'))
+    # Create unique directory
+    data_dir = helpers.get_data_directory()
+    unique_directory = tempfile.mkdtemp(prefix="research", dir=data_dir)
+    transfer_dir = os.path.join(data_dir, unique_directory)
 
-    return "Unsuitable form data submitted", status.HTTP_400_BAD_REQUEST
+    # Save files
+    files = request.files.getlist("files")
+
+    filecount = 0
+    for file in files:
+        filename = secure_filename(file.filename)
+
+        # An empty directory sent won't have a filename
+        if filename != "":
+            filepath = os.path.join(transfer_dir, filename)
+
+            with open(filepath, 'wb') as f:
+                f.write(file.read())
+
+            filecount += 1
+
+    # Abort if noting was actually uploaded
+    if not filecount:
+        flash("No files were uploaded", "danger")
+        return redirect(url_for('transfer.index'))
+
+    # Set default permissions
+    permission_file_path = os.path.join(transfer_dir, permissions.PERMISSION_METADATA_FILENAME)
+    perms = permissions.FilePermissions(permission_file_path)
+
+    for file in helpers.get_all_filepaths_in_directory(transfer_dir, False):
+        entry_path = os.path.join(transfer_dir, file)
+        perms.set(entry_path, "private")
+
+    perms.save()
+
+    # Change transfer directory
+    session["transfer_directory"] = transfer_dir
+    session.modified = True
+
+    flash("Files have been uploaded", "primary")
+    return redirect(url_for('transfer.index'))

--- a/uploader/Upload/job.py
+++ b/uploader/Upload/job.py
@@ -1,0 +1,129 @@
+import json
+import os
+import shutil
+import threading
+
+import sqlite3
+
+from uploader.Metadata import DATAVERSE_METADATA_FILENAME
+from uploader.Navigator import permissions
+
+
+class Job(threading.Thread):
+    conn = None  # Connection for job management
+    __conn = None  # Connection for thread
+
+    params = {}
+    default_user_id = 1
+    id = None
+
+    def params(self, params):
+        self.params = params
+
+    def new_conn(self):
+        return sqlite3.connect("jobs.db")
+
+    def get_conn(self):
+        if self.conn is None:
+            self.conn = self.new_conn()
+        return self.conn
+
+    def begin(self, job_type, job_params):
+        # Set user ID
+        if "user_id" in job_params:
+            user_id = job_params["user_id"]
+        else:
+            user_id = self.default_user_id
+
+        self.__conn = self.new_conn()  # Open new connection for thread
+
+        # Create table if needed
+        cur = self.__conn.cursor()
+        cur.execute(
+            "CREATE TABLE IF NOT EXISTS job( \
+                id INTEGER PRIMARY KEY, \
+                user_id INTEGER, \
+                job_type TEXT, \
+                params TEXT, \
+                complete INT \
+            )"
+        )
+
+        # Note that job has started
+        cur.execute(
+            "INSERT INTO job \
+                (user_id, job_type, params, complete) \
+                VALUES (?, ?, ?, ?)",
+            (user_id, job_type, json.dumps(job_params), 0),
+        )
+        self.__conn.commit()
+
+        self.id = cur.lastrowid
+
+    def end(self):
+        # Mark job as complete
+        cur = self.__conn.cursor()
+        cur.execute("UPDATE job SET complete=1 WHERE id=?", (self.id,))
+        self.__conn.commit()
+
+    def list(self, user_id=None):
+        # Return list of jobs
+        cur = self.get_conn().cursor()
+
+        if user_id is None:
+            res = cur.execute("SELECT * FROM job")
+        else:
+            res = cur.execute("SELECT * FROM job WHERE user_id=?", (user_id,))
+
+        return res.fetchall()
+
+    def clear(self, user_id=None):
+        # Clear jobs
+        cur = self.get_conn().cursor()
+
+        if user_id is None:
+            res = cur.execute("DELETE FROM job")
+        else:
+            res = cur.execute("DELETE FROM job WHERE user_id=?", (user_id,))
+
+        self.conn.commit()
+
+
+class CreateTransferJob(Job):
+    def run(self):
+        super().begin("copy", self.params)
+
+        # Copy transfer files to transfer source location
+        shutil.copytree(self.params["source"], self.params["destination"])
+
+        # Create metadata directory if need be
+        metadata_directory = os.path.join(self.params["destination"], "metadata")
+
+        if not os.path.isdir(metadata_directory):
+            os.mkdir(metadata_directory)
+
+        # Move main metadata file, if it exists, to metadata directory
+        main_metadata_filepath = os.path.join(self.params["destination"], DATAVERSE_METADATA_FILENAME)
+
+        if os.path.isfile(main_metadata_filepath):
+            shutil.copy(main_metadata_filepath, metadata_directory)
+            os.remove(main_metadata_filepath)
+
+        # Get file permission metadata, if it exists, and write it as a
+        # metadata.csv file to the metadata directory
+        permission_file_path = os.path.join(self.params["destination"], permissions.PERMISSION_METADATA_FILENAME)
+
+        if os.path.isfile(permission_file_path):
+            # Load file permission metadata
+            csv_dest_filepath = os.path.join(metadata_directory, "metadata.csv")
+
+            perms = permissions.FilePermissions(permission_file_path)
+            perms.load()
+
+            # Write file permission metadata to metadata.csv in metadata directory
+            perms.write_permissions_to_csv(self.params["destination"], csv_dest_filepath)
+
+            # Remove old file permission metadata file
+            os.remove(permission_file_path)
+
+        super().end()

--- a/uploader/Upload/templates/upload.html
+++ b/uploader/Upload/templates/upload.html
@@ -4,22 +4,28 @@
 
   <div class="container mt-5">
 
-    <h2>Research Data Upload</h2>
+    <h2>Import Into Archivematica</h2>
 
     {% if transfer_directory|length: %}
       <table>
         <tr>
           <td>File count: </td>
-          <td>{{ transfer_file_count }}</td>
+          <td><code>{{ transfer_file_count }}</code> <span class="text-muted small">(including generated metadata)</span></td>
         </tr>
         <tr>
           <td>Total size of files: </td>
-          <td>{{ transfer_total_file_size|filesizeformat }}</td>
+          <td><code>{{ transfer_total_file_size|filesizeformat }}</code></td>
         </tr>
       </table>
       <br/>
 
       <p><a href="/files/preview">Preview file permission metadata</a></p>
+
+      <form action="{{ url_for('upload.send') }}" method="POST">
+        <input name="transfer_name" placeholder="Transfer name" />
+        <input type="submit" value="Import" class="btn btn-primary"/>
+      </form>
+
     {% else %}
       <p>No research data directory specified yet.</p>
     {% endif %}

--- a/uploader/Upload/views.py
+++ b/uploader/Upload/views.py
@@ -1,16 +1,51 @@
 # -*- coding: utf-8 -*-
 
 import os
-from flask import Blueprint, render_template
+from flask import (
+    Blueprint,
+    current_app,
+    render_template,
+    url_for,
+    request,
+    redirect,
+    flash,
+)
 from flask_api import status
 
+from uploader.Upload import job
 from uploader.Transfer import helpers
 
 upload = Blueprint("upload", __name__, template_folder="templates")
 
-@upload.route('/')
-def index():
-    transfer_dir = helpers.get_transfer_directory(True)
-    transfer_file_count, transfer_total_file_size = helpers.directory_count_and_size(transfer_dir)
 
-    return render_template('upload.html', transfer_directory=transfer_dir, transfer_file_count=transfer_file_count, transfer_total_file_size=transfer_total_file_size)
+@upload.route("/", methods=["GET"])
+def index():
+    transfer_dir = helpers.get_transfer_directory()
+    transfer_file_count, transfer_total_file_size = helpers.directory_count_and_size(
+        transfer_dir
+    )
+
+    return render_template(
+        "upload.html",
+        transfer_directory=transfer_dir,
+        transfer_file_count=transfer_file_count,
+        transfer_total_file_size=transfer_total_file_size,
+    )
+
+
+@upload.route("/", methods=["POST"])
+def send():
+    transfer_dir = helpers.get_transfer_directory()
+    transfer_source_dir = current_app.config["TRANSFER_SOURCE_DIRECTORY"]
+
+    transfer_name = request.form["transfer_name"]
+
+    # Perform copy asynchronously
+    destination_dir = os.path.join(transfer_source_dir, transfer_name)
+
+    u = job.CreateTransferJob()
+    u.params({"source": transfer_dir, "destination": destination_dir})
+    u.start()
+
+    flash("Copy started.", "primary")
+    return redirect(url_for("upload.index"))

--- a/uploader/__init__.py
+++ b/uploader/__init__.py
@@ -24,10 +24,10 @@ def create_app(config_name="default"):
 
         # Define navigation bar
         navbar = NavBar()
-        navbar.add("Select Research Data", "transfer.index")
+        navbar.add("Upload Research Data", "transfer.index")
         navbar.add("Metadata", "metadata.index")
         navbar.add("File Permissions", "navigator.index")
-        navbar.add("Upload", "upload.index")
+        navbar.add("Archivematica", "upload.index")
 
         # Inject navigation bar into templates
         @app.context_processor

--- a/uploader/navbar/__init__.py
+++ b/uploader/navbar/__init__.py
@@ -16,7 +16,7 @@ class NavBarItem:
 
     def is_visible(self):
         transfer_directory = helpers.get_transfer_directory()
-        return self.route != "navigator.index" or transfer_directory
+        return self.route == "transfer.index" or transfer_directory
 
 
 class NavBar:


### PR DESCRIPTION
* Added ability to upload a ZIP-compressed folder of research data

* Set all file permission metadata in research data to "Private"

* Added asynchronous job class and a job that 1) arranges research data and metadata in an Archivematica transfer format and 2) copies the resulting transfer to an Archivematica transfer source directory

* Renamed navigation tabs for clarity

* Add TRANSFER_SOURCE_DIRECTORY config variable and rename TRANSFER_DIRECTORY config variable to differentiate it

Dataverse metadata-related:
* Write Dataverse metadata to file upon successful submission

* Don't allow Dataverse metadata's file permission metadata to be set

* Add placeholder "done" page to be shown after successful submission of Dataverse metadata