### PR TITLE
Bulk setting of dir permissions in navigator

### DIFF
--- a/uploader/Navigator/permissions.py
+++ b/uploader/Navigator/permissions.py
@@ -2,6 +2,8 @@ import csv
 import json
 import os
 
+from uploader.Transfer import helpers
+
 
 PERMISSION_METADATA_FILENAME = "permissions.json"
 
@@ -42,6 +44,14 @@ class FilePermissions:
             return self.permissions[entry_path]
 
         return None
+
+    # Set permissions for all descendants of an entry
+    def set_descendant_perms(self, entry_path, permission):
+        files = helpers.get_all_filepaths_in_directory(entry_path, False)
+
+        for filepath in files:
+            if filepath.startswith(entry_path + "/"):
+                self.set(filepath, permission)
 
     # Write permissions to an Archivematica metadata CSV file
     def write_permissions_to_csv(self, transfer_dir, destination_csv_file_path):

--- a/uploader/Navigator/views.py
+++ b/uploader/Navigator/views.py
@@ -55,7 +55,10 @@ def index(req_path):
             if form_field_name in request.form:
                 permission = request.form[form_field_name]
 
-                perms.set(entry_path, permission)
+                if os.path.isdir(entry_path) and permission != "":
+                    perms.set_descendant_perms(entry_path, permission)
+                else:
+                    perms.set(entry_path, permission)
 
         perms.save()
 
@@ -80,9 +83,6 @@ def index(req_path):
             entry['settable'] = False
 
         if req_path == "" and file == DATAVERSE_METADATA_FILENAME:
-            entry['settable'] = False
-
-        if os.path.isdir(entry_path):
             entry['settable'] = False
 
         if not entry["is_dir"]:


### PR DESCRIPTION
Added logic, in the file permissions navigator, to display a permissiom pull-down for directories and set the directory's contents in bulk.