### PR TITLE
File upload UI improvement

### DIFF
--- a/uploader/Transfer/templates/transfer.html
+++ b/uploader/Transfer/templates/transfer.html
@@ -1,5 +1,9 @@
 {% extends "base.html" %}
 
+{% block head %}
+   <script defer src="../static/upload.js"></script>
+{% endblock %}
+
 {% block content %}
 
   <div class="container mt-5">
@@ -30,8 +34,13 @@
 
     </br>
     <form action="{{ url_for('transfer.upload') }}" method="POST" enctype="multipart/form-data">
-      <input name="files" type="file" webkitdirectory directory />
-      <input type=submit value="Upload" class="btn btn-primary"/>
+      <input id="chooserProxy" type="button" value="Choose directory" />
+      <input id="chooser" name="files" type="file" webkitdirectory directory class="collapse" />
+
+      <button id="chooserSubmit" type="submit" class="btn btn-primary">Upload</button>
+      <div id="chooserSpinner" class="spinner-border text-primary invisible" role="status">
+        <span class="visually-hidden">Loading...</span>
+      </div>
     </form>
 
   </div>

--- a/uploader/static/upload.js
+++ b/uploader/static/upload.js
@@ -1,0 +1,16 @@
+$chooserProxy = document.getElementById('chooserProxy');
+$chooser = document.getElementById('chooser');
+$chooserSubmit = document.getElementById('chooserSubmit');
+$chooserSpinner = document.getElementById('chooserSpinner');
+
+// Show directory picker when proxy is clicked
+$chooserProxy.addEventListener("click", function() {
+  $chooser.click();
+});
+
+// Hide directory picker, etc., and show spinner when starting upload
+$chooserSubmit.addEventListener("click", function() {
+  $chooserProxy.style.display = "none";
+  $chooserSubmit.style.display = "none";
+  $chooserSpinner.classList.remove("invisible");
+});


### PR DESCRIPTION
On transfer upload page change "Choose file" to "Choose directory". Hide directory picker and submit button when uploading and show "spinner" animation.