### PR TITLE
Allow config file variations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ uploader/__pycache__/
 uploader/Navigator/__pycache__/
 config.pyc
 *.pyc
+.config.yaml

--- a/README.md
+++ b/README.md
@@ -138,8 +138,9 @@ in your browser.
 </ol>
 
 ## Configuration
-Configuration is specified, using YAML, in `/etc/umcu-uploader.yaml`. The
-various configuration settings are detailed below:
+Configuration is specified, using YAML, either in `.config.yaml` in the
+application directory or in `/etc/umcu-uploader.yaml`. The various
+configuration settings are detailed below:
 
 
 | Setting                            | Description                                                          | Default                              |

--- a/config.py
+++ b/config.py
@@ -1,4 +1,4 @@
-from uploader.configutil import set_config_from_yaml
+from uploader.configutil import get_config_file, set_config_from_yaml
 
 
 # Specifiy config fields and defaults
@@ -28,9 +28,11 @@ class Config:
 
 
 # Populate config with values from YAML file, if available
-config_filepath = "/etc/umcu-uploader.yaml"
+config_filepath = get_config_file()
 
 try:
+    print(f"Attempting to read config file {config_filepath}...\n")
+
     set_config_from_yaml(Config, config_fields, config_filepath)
 
 except (FileNotFoundError, IOError):

--- a/uploader/configutil.py
+++ b/uploader/configutil.py
@@ -1,6 +1,18 @@
 import os
 import yaml
 
+CONFIG_FILE_LOCATIONS = [".config.yaml", "/etc/umcu-uploader.yaml"]
+
+
+def get_config_file():
+    # Return first file found in possible config file locations
+    for config_file in CONFIG_FILE_LOCATIONS:
+        if os.path.isfile(config_file):
+            return config_file
+
+    # Return first possible config file in list as suggestion
+    return config_file[0]
+
 
 def set_config_from_yaml(config, config_fields, config_filepath):
     # Set default config values


### PR DESCRIPTION
Allow the config file to either be in the application directory (.config.yaml) or the /etc dircetory (/etc/umcu-uploader.yaml).