### PR TITLE
License metadata upload fix. (#100)

### DIFF
--- a/uploader/Dataverse/jobs.py
+++ b/uploader/Dataverse/jobs.py
@@ -109,8 +109,13 @@ class CreateDataverseDatasetFromAipJob(Job):
                     ],
                 }
             )
-            json.dump(dv_json, dv_json_file)
-            ds.from_json(json.dumps(dv_json), validate=False)
+
+            # Make slight metadata change to accord with pyDataverse client
+            dv_json["datasetVersion"]["license"] = dv_json["datasetVersion"]["license"][
+                "name"
+            ]
+
+            ds.from_json(json.dumps(dv_json))
 
         # Get the division acronym from the metadata in the AIP
         arc_metadata_filepath = os.path.join(


### PR DESCRIPTION
Fixes license metadata upload issue.

pyDataverse's Dataverse metadata schema
(pyDataverse/schemas/json/dataset_upload_default_schema.json in their Github repository) seems to accept license as a string (as Dataverse's Native API seems to have previously done in version 4) rather than an object with "name" and "uri" values.

Made slight change to Dataverse upload job to note this and work around it.