### PR TITLE
Fix license metadata issues (#100)

### DIFF
--- a/uploader/Dataverse/jobs.py
+++ b/uploader/Dataverse/jobs.py
@@ -111,9 +111,10 @@ class CreateDataverseDatasetFromAipJob(Job):
             )
 
             # Make slight metadata change to accord with pyDataverse client
-            dv_json["datasetVersion"]["license"] = dv_json["datasetVersion"]["license"][
-                "name"
-            ]
+            if "license" in dv_json["datasetVersion"]:
+                dv_json["datasetVersion"]["license"] = dv_json["datasetVersion"][
+                    "license"
+                ]["name"]
 
             ds.from_json(json.dumps(dv_json))
 

--- a/uploader/Metadata/dataverse_metadata.py
+++ b/uploader/Metadata/dataverse_metadata.py
@@ -113,9 +113,6 @@ def parse_form_data(form: dict) -> list:
 def dv_json(form: dict) -> None:
     dv_metadata = {
         "datasetVersion": {
-            "license": {
-                "name:": form["licence"],
-            },
             "termsOfUse": form["licenceDescription"],
             "metadataBlocks": {
                 "citation": {


### PR DESCRIPTION
During creation of Dataverse metadata don't add license metadata to invalid license types.

During export to Dataverse make sure Dataverse metadata includes license metadata before trying to modify it.